### PR TITLE
Implement simple comment board

### DIFF
--- a/backend/comments.go
+++ b/backend/comments.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"sync"
+)
+
+type Comment struct {
+	ID   int    `json:"id"`
+	Text string `json:"text"`
+}
+
+var (
+	comments   []Comment
+	commentsMu sync.Mutex
+)
+
+func commentsHandler(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		commentsMu.Lock()
+		defer commentsMu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(comments)
+	case http.MethodPost:
+		var c struct {
+			Text string `json:"text"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&c); err != nil {
+			http.Error(w, "invalid body", http.StatusBadRequest)
+			return
+		}
+		commentsMu.Lock()
+		id := len(comments) + 1
+		comments = append(comments, Comment{ID: id, Text: c.Text})
+		commentsMu.Unlock()
+		w.WriteHeader(http.StatusCreated)
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -10,6 +10,8 @@ func main() {
 		fmt.Fprintln(w, "Hello from Go backend!")
 	})
 
+	http.HandleFunc("/api/comments", commentsHandler)
+
 	fmt.Println("Server started at :8080")
 	http.ListenAndServe(":8080", nil)
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "react-router-dom": "^6.23.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,31 +1,19 @@
+import { BrowserRouter as Router, Routes, Route, Link } from 'react-router-dom'
+import Home from './pages/Home.jsx'
+import Board from './pages/Board.jsx'
 import './App.css'
 
 function App() {
   return (
-    <div className="portfolio">
-      <header>
-        <h1>Shiho-chan's Portfolio</h1>
-        <p>ようこそ、私のポートフォリオサイトへ！</p>
-      </header>
-      <section>
-        <h2>自己紹介</h2>
-        <p>ここに自己紹介文を入れます。興味のある分野や経歴などを書いてください。</p>
-      </section>
-      <section>
-        <h2>作品</h2>
-        <ul>
-          <li>Project A - 紹介文など</li>
-          <li>Project B - 紹介文など</li>
-          <li>Project C - 紹介文など</li>
-        </ul>
-      </section>
-      <section>
-        <h2>連絡先</h2>
-        <p>
-          ご連絡は <a href="mailto:shihochan@example.com">shihochan@example.com</a> までお願いします。
-        </p>
-      </section>
-    </div>
+    <Router>
+      <nav>
+        <Link to="/">Home</Link> | <Link to="/board">掲示板</Link>
+      </nav>
+      <Routes>
+        <Route path="/" element={<Home />} />
+        <Route path="/board" element={<Board />} />
+      </Routes>
+    </Router>
   )
 }
 

--- a/frontend/src/pages/Board.jsx
+++ b/frontend/src/pages/Board.jsx
@@ -1,0 +1,40 @@
+import { useEffect, useState } from 'react'
+import '../App.css'
+
+function Board() {
+  const [comments, setComments] = useState([])
+  const [text, setText] = useState('')
+
+  useEffect(() => {
+    fetch('/api/comments')
+      .then(res => res.json())
+      .then(setComments)
+  }, [])
+
+  const submit = async (e) => {
+    e.preventDefault()
+    await fetch('/api/comments', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text })
+    })
+    setText('')
+    const res = await fetch('/api/comments')
+    setComments(await res.json())
+  }
+
+  return (
+    <div className="board">
+      <h1>掲示板</h1>
+      <form onSubmit={submit}>
+        <input value={text} onChange={e => setText(e.target.value)} />
+        <button type="submit">投稿</button>
+      </form>
+      <ul>
+        {comments.map(c => <li key={c.id}>{c.text}</li>)}
+      </ul>
+    </div>
+  )
+}
+
+export default Board

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -1,0 +1,32 @@
+import '../App.css'
+
+function App() {
+  return (
+    <div className="portfolio">
+      <header>
+        <h1>Shiho-chan's Portfolio</h1>
+        <p>ようこそ、私のポートフォリオサイトへ！</p>
+      </header>
+      <section>
+        <h2>自己紹介</h2>
+        <p>ここに自己紹介文を入れます。興味のある分野や経歴などを書いてください。</p>
+      </section>
+      <section>
+        <h2>作品</h2>
+        <ul>
+          <li>Project A - 紹介文など</li>
+          <li>Project B - 紹介文など</li>
+          <li>Project C - 紹介文など</li>
+        </ul>
+      </section>
+      <section>
+        <h2>連絡先</h2>
+        <p>
+          ご連絡は <a href="mailto:shihochan@example.com">shihochan@example.com</a> までお願いします。
+        </p>
+      </section>
+    </div>
+  )
+}
+
+export default App


### PR DESCRIPTION
## Summary
- add in-memory comment API on backend
- add react-router and new Board page on frontend
- hook up Home page to router
- link to new board in nav

## Testing
- `go test ./...` *(fails: pattern ./...: directory prefix . does not contain main module or its selected dependencies)*
- `npm --prefix frontend run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68452a54656c8322b016e9d507b157de