### PR TITLE
Fix dev server API connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# Codex Sample Project
+
+This repository contains a simple Go backend and a React frontend. To run the project locally:
+
+1. Start the Go backend on port `8080`:
+
+```bash
+go run ./backend
+```
+
+2. In another terminal, start the React frontend with Vite:
+
+```bash
+cd frontend
+npm install # first time only
+npm run dev
+```
+
+The Vite dev server proxies API requests under `/api` to the Go backend, so posting comments on the board page should work when both servers are running.

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -4,4 +4,9 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    proxy: {
+      '/api': 'http://localhost:8080'
+    }
+  }
 })


### PR DESCRIPTION
## Summary
- add instructions for running backend and frontend together
- configure Vite dev server to proxy `/api` requests to Go backend

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68452d05a83483229a56f6dcce63711e