### PR TITLE
Add comment deletion and modernize styling

### DIFF
--- a/backend/comments.go
+++ b/backend/comments.go
@@ -3,6 +3,8 @@ package main
 import (
 	"encoding/json"
 	"net/http"
+	"strconv"
+	"strings"
 	"sync"
 )
 
@@ -13,8 +15,13 @@ type Comment struct {
 
 var (
 	comments   []Comment
+	nextID     int
 	commentsMu sync.Mutex
 )
+
+func init() {
+	nextID = 1
+}
 
 func commentsHandler(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
@@ -32,10 +39,40 @@ func commentsHandler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		commentsMu.Lock()
-		id := len(comments) + 1
+		id := nextID
+		nextID++
 		comments = append(comments, Comment{ID: id, Text: c.Text})
 		commentsMu.Unlock()
 		w.WriteHeader(http.StatusCreated)
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+func commentByIDHandler(w http.ResponseWriter, r *http.Request) {
+	idStr := strings.TrimPrefix(r.URL.Path, "/api/comments/")
+	id, err := strconv.Atoi(idStr)
+	if err != nil {
+		http.Error(w, "invalid id", http.StatusBadRequest)
+		return
+	}
+	commentsMu.Lock()
+	defer commentsMu.Unlock()
+	index := -1
+	for i, c := range comments {
+		if c.ID == id {
+			index = i
+			break
+		}
+	}
+	if index == -1 {
+		http.NotFound(w, r)
+		return
+	}
+	switch r.Method {
+	case http.MethodDelete:
+		comments = append(comments[:index], comments[index+1:]...)
+		w.WriteHeader(http.StatusNoContent)
 	default:
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 	}

--- a/backend/main.go
+++ b/backend/main.go
@@ -10,6 +10,7 @@ func main() {
 		fmt.Fprintln(w, "Hello from Go backend!")
 	})
 
+	http.HandleFunc("/api/comments/", commentByIDHandler)
 	http.HandleFunc("/api/comments", commentsHandler)
 
 	fmt.Println("Server started at :8080")

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,9 +1,21 @@
 #root {
+  --primary: #4f46e5;
+  --danger: #e11d48;
+  --bg: #f5f5f5;
+  --text: #333;
   max-width: 800px;
   margin: 0 auto;
   padding: 2rem;
   font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;
+  background-color: var(--bg);
+  color: var(--text);
+}
+
+nav {
+  display: flex;
+  gap: 1rem;
+  margin-bottom: 2rem;
 }
 
 header {
@@ -28,4 +40,40 @@ h2 {
 ul {
   list-style: square inside;
   padding-left: 0;
+}
+
+.board ul {
+  list-style: none;
+  padding: 0;
+}
+
+.board li {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: #fff;
+  margin-bottom: 0.5rem;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+}
+
+input {
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  margin-right: 0.5rem;
+}
+
+button {
+  padding: 0.5rem 1rem;
+  border: none;
+  border-radius: 4px;
+  background: var(--primary);
+  color: white;
+  cursor: pointer;
+}
+
+button.delete {
+  background: var(--danger);
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -3,9 +3,8 @@
   line-height: 1.5;
   font-weight: 400;
 
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
+  color: #213547;
+  background-color: #f5f5f5;
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;
@@ -24,8 +23,6 @@ a:hover {
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
   min-width: 320px;
   min-height: 100vh;
 }
@@ -33,36 +30,4 @@ body {
 h1 {
   font-size: 3.2em;
   line-height: 1.1;
-}
-
-button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
 }

--- a/frontend/src/pages/Board.jsx
+++ b/frontend/src/pages/Board.jsx
@@ -23,6 +23,12 @@ function Board() {
     setComments(await res.json())
   }
 
+  const remove = async (id) => {
+    await fetch(`/api/comments/${id}`, { method: 'DELETE' })
+    const res = await fetch('/api/comments')
+    setComments(await res.json())
+  }
+
   return (
     <div className="board">
       <h1>掲示板</h1>
@@ -31,7 +37,12 @@ function Board() {
         <button type="submit">投稿</button>
       </form>
       <ul>
-        {comments.map(c => <li key={c.id}>{c.text}</li>)}
+        {comments.map(c => (
+          <li key={c.id}>
+            {c.text}
+            <button onClick={() => remove(c.id)} className="delete">削除</button>
+          </li>
+        ))}
       </ul>
     </div>
   )


### PR DESCRIPTION
## Summary
- support DELETE for comments in the Go backend
- update Board page to allow comment deletion
- restyle app with modern CSS

## Testing
- `go build ./...` *(fails: Forbidden)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68452ff73488832286962ae97cf860e4