### PR TITLE
Add login with admin and user roles

### DIFF
--- a/backend/comments.go
+++ b/backend/comments.go
@@ -1,26 +1,67 @@
 package main
 
 import (
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"net/http"
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 )
 
 type Comment struct {
-	ID   int    `json:"id"`
-	Text string `json:"text"`
+	ID        int    `json:"id"`
+	Username  string `json:"username"`
+	Name      string `json:"name"`
+	Text      string `json:"text"`
+	Timestamp string `json:"timestamp"`
 }
 
 var (
 	comments   []Comment
 	nextID     int
 	commentsMu sync.Mutex
+
+	users = map[string]struct {
+		Password string
+		Role     string
+	}{
+		"admin": {Password: "password", Role: "admin"},
+		"user":  {Password: "password", Role: "user"},
+	}
+
+	sessions   = make(map[string]string)
+	sessionsMu sync.Mutex
 )
 
 func init() {
 	nextID = 1
+}
+
+func newToken() string {
+	b := make([]byte, 16)
+	rand.Read(b)
+	return hex.EncodeToString(b)
+}
+
+func getUser(r *http.Request) (string, string, bool) {
+	cookie, err := r.Cookie("session")
+	if err != nil {
+		return "", "", false
+	}
+	sessionsMu.Lock()
+	username, ok := sessions[cookie.Value]
+	sessionsMu.Unlock()
+	if !ok {
+		return "", "", false
+	}
+	user, ok := users[username]
+	if !ok {
+		return "", "", false
+	}
+	return username, user.Role, true
 }
 
 func commentsHandler(w http.ResponseWriter, r *http.Request) {
@@ -31,7 +72,13 @@ func commentsHandler(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(comments)
 	case http.MethodPost:
+		username, _, ok := getUser(r)
+		if !ok {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
 		var c struct {
+			Name string `json:"name"`
 			Text string `json:"text"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&c); err != nil {
@@ -41,7 +88,13 @@ func commentsHandler(w http.ResponseWriter, r *http.Request) {
 		commentsMu.Lock()
 		id := nextID
 		nextID++
-		comments = append(comments, Comment{ID: id, Text: c.Text})
+		comments = append(comments, Comment{
+			ID:        id,
+			Username:  username,
+			Name:      c.Name,
+			Text:      c.Text,
+			Timestamp: time.Now().Format(time.RFC3339),
+		})
 		commentsMu.Unlock()
 		w.WriteHeader(http.StatusCreated)
 	default:
@@ -71,9 +124,61 @@ func commentByIDHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	switch r.Method {
 	case http.MethodDelete:
+		username, role, ok := getUser(r)
+		if !ok {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		if role != "admin" && comments[index].Username != username {
+			http.Error(w, "forbidden", http.StatusForbidden)
+			return
+		}
 		comments = append(comments[:index], comments[index+1:]...)
 		w.WriteHeader(http.StatusNoContent)
 	default:
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 	}
+}
+
+func loginHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	var creds struct {
+		Username string `json:"username"`
+		Password string `json:"password"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&creds); err != nil {
+		http.Error(w, "invalid body", http.StatusBadRequest)
+		return
+	}
+	u, ok := users[creds.Username]
+	if !ok || u.Password != creds.Password {
+		http.Error(w, "invalid credentials", http.StatusUnauthorized)
+		return
+	}
+	token := newToken()
+	sessionsMu.Lock()
+	sessions[token] = creds.Username
+	sessionsMu.Unlock()
+	http.SetCookie(w, &http.Cookie{Name: "session", Value: token, Path: "/", HttpOnly: true})
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(struct {
+		Username string `json:"username"`
+		Role     string `json:"role"`
+	}{creds.Username, u.Role})
+}
+
+func meHandler(w http.ResponseWriter, r *http.Request) {
+	username, role, ok := getUser(r)
+	if !ok {
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(struct {
+		Username string `json:"username"`
+		Role     string `json:"role"`
+	}{username, role})
 }

--- a/backend/main.go
+++ b/backend/main.go
@@ -10,6 +10,8 @@ func main() {
 		fmt.Fprintln(w, "Hello from Go backend!")
 	})
 
+	http.HandleFunc("/api/login", loginHandler)
+	http.HandleFunc("/api/me", meHandler)
 	http.HandleFunc("/api/comments/", commentByIDHandler)
 	http.HandleFunc("/api/comments", commentsHandler)
 

--- a/frontend/src/pages/Board.jsx
+++ b/frontend/src/pages/Board.jsx
@@ -4,43 +4,74 @@ import '../App.css'
 function Board() {
   const [comments, setComments] = useState([])
   const [text, setText] = useState('')
+  const [name, setName] = useState('')
+  const [user, setUser] = useState(null)
+  const [username, setUsername] = useState('')
+  const [password, setPassword] = useState('')
+
+  const fetchComments = async () => {
+    const res = await fetch('/api/comments')
+    setComments(await res.json())
+  }
 
   useEffect(() => {
-    fetch('/api/comments')
-      .then(res => res.json())
-      .then(setComments)
+    fetch('/api/me').then(async res => {
+      if (res.ok) setUser(await res.json())
+    })
+    fetchComments()
   }, [])
+
+  const login = async (e) => {
+    e.preventDefault()
+    const res = await fetch('/api/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username, password })
+    })
+    if (res.ok) setUser(await res.json())
+  }
 
   const submit = async (e) => {
     e.preventDefault()
     await fetch('/api/comments', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ text })
+      body: JSON.stringify({ name, text })
     })
     setText('')
-    const res = await fetch('/api/comments')
-    setComments(await res.json())
+    setName('')
+    fetchComments()
   }
 
   const remove = async (id) => {
     await fetch(`/api/comments/${id}`, { method: 'DELETE' })
-    const res = await fetch('/api/comments')
-    setComments(await res.json())
+    fetchComments()
   }
 
   return (
     <div className="board">
       <h1>掲示板</h1>
+      {user ? (
+        <p>Logged in as {user.username} ({user.role})</p>
+      ) : (
+        <form onSubmit={login}>
+          <input placeholder="Username" value={username} onChange={e => setUsername(e.target.value)} />
+          <input type="password" placeholder="Password" value={password} onChange={e => setPassword(e.target.value)} />
+          <button type="submit">Login</button>
+        </form>
+      )}
       <form onSubmit={submit}>
+        <input placeholder="Handle" value={name} onChange={e => setName(e.target.value)} />
         <input value={text} onChange={e => setText(e.target.value)} />
         <button type="submit">投稿</button>
       </form>
       <ul>
         {comments.map(c => (
           <li key={c.id}>
-            {c.text}
-            <button onClick={() => remove(c.id)} className="delete">削除</button>
+            <span>{c.name} ({new Date(c.timestamp).toLocaleString()}): {c.text}</span>
+            {user && (user.role === 'admin' || user.username === c.username) && (
+              <button onClick={() => remove(c.id)} className="delete">削除</button>
+            )}
           </li>
         ))}
       </ul>


### PR DESCRIPTION
## Summary
- add session-based login in Go backend
- include username, handle, and timestamp on comments
- allow admins to delete any comment and users to remove their own
- expose login API endpoints and return current user info
- update board page with login form, handle name input, and timestamp display

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `go vet ./...` *(fails: Get https://proxy.golang.org/... Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684537701df483228af8d763507bf915